### PR TITLE
Added condition to fetch inactive user message from config

### DIFF
--- a/src/forgot-password/ForgotPasswordAlert.jsx
+++ b/src/forgot-password/ForgotPasswordAlert.jsx
@@ -45,7 +45,12 @@ const ForgotPasswordAlert = (props) => {
       );
      break;
     case INTERNAL_SERVER_ERROR:
-      message = formatMessage(messages['internal.server.error']);
+      const inactive_msg = getConfig().INACTIVE_USER_MESSAGE;
+      message = inactive_msg ? (
+        <div dangerouslySetInnerHTML={{ __html: inactive_msg }} />
+      ) : (
+        formatMessage(messages['internal.server.error'])
+      );
       break;
     case FORBIDDEN_STATE:
       heading = formatMessage(messages['forgot.password.error.message.title']);

--- a/src/login/LoginFailure.jsx
+++ b/src/login/LoginFailure.jsx
@@ -35,7 +35,7 @@ const LoginFailureMessage = (props) => {
       {formatMessage(messages['login.incorrect.credentials.error.reset.link.text'])}
     </Hyperlink>
   );
-
+  const inactive_msg = getConfig().INACTIVE_USER_MESSAGE;
   switch (errorCode) {
     case NON_COMPLIANT_PASSWORD_EXCEPTION: {
       errorList = (
@@ -57,6 +57,9 @@ const LoginFailureMessage = (props) => {
       );
       errorList = (
         <p>
+          {inactive_msg ? (
+        <span dangerouslySetInnerHTML={{ __html: inactive_msg }} />
+        ) : (
           <FormattedMessage
             id="login.inactive.user.error"
             defaultMessage="Your account has been deactivated. Please contact your support for more information."
@@ -66,6 +69,7 @@ const LoginFailureMessage = (props) => {
               supportLink,
             }}
           />
+    )}
         </p>
       );
       break;


### PR DESCRIPTION
### Description

Include a description of your changes here, along with a link to any relevant Jira tickets and/or Github issues.

#### JIRA

[XXX-XXXX](https://2u-internal.atlassian.net/browse/XXX-XXXX)

#### How Has This Been Tested?

Please describe in detail how you tested your changes.

#### Screenshots/sandbox (optional):

Include a link to the sandbox for design changes or screenshot for before and after. **Remove this section if its not applicable.**

|Before|After|
|-------|-----|
|      |      |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/2u-vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
